### PR TITLE
tsconfig 의존성을 dependencies로 이동

### DIFF
--- a/tsconfig/package-lock.json
+++ b/tsconfig/package-lock.json
@@ -1,22 +1,21 @@
 {
   "name": "@day1co/tsconfig",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@day1co/tsconfig",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
-      "devDependencies": {
+      "dependencies": {
         "@tsconfig/node-lts": "^18.12.1"
       }
     },
     "node_modules/@tsconfig/node-lts": {
       "version": "18.12.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node-lts/-/node-lts-18.12.1.tgz",
-      "integrity": "sha512-UkIaMWDwJ+qJX/os8lzYh7m47qQJY7sIp1WZiEStASrpzczp27+jA0fJES+IjnS2OlDDLeBghNrVkKw8iYIRdA==",
-      "dev": true
+      "integrity": "sha512-UkIaMWDwJ+qJX/os8lzYh7m47qQJY7sIp1WZiEStASrpzczp27+jA0fJES+IjnS2OlDDLeBghNrVkKw8iYIRdA=="
     }
   }
 }

--- a/tsconfig/package.json
+++ b/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@day1co/tsconfig",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Day1Company",
   "license": "MIT",
   "repository": {
@@ -10,7 +10,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
-  "devDependencies": {
+  "dependencies": {
     "@tsconfig/node-lts": "^18.12.1"
   }
 }


### PR DESCRIPTION
`@day1co/tsconfig`를 install하고,
`@tsconfig/node-lts`를 별도로 install해야 하는 상황을 피하기 위함.