### PR TITLE
tsconfig에서 경로 관련 속성 삭제 및 @tsconfig/node-lts 의존성 수정

### DIFF
--- a/tsconfig/README.md
+++ b/tsconfig/README.md
@@ -18,19 +18,35 @@ for Both Frontend and Backend:
 
 ```json
 "extends": "@day1co/tsconfig/common.json"
+"compilerOptions": {
+  "outDir": "./lib"
+},
+"include": ["./src"],
+"exclude": ["./lib", "./node_modules"]
 ```
 
 for Backend:
 
 ```json
 "extends": "@day1co/tsconfig/backend.json"
+"compilerOptions": {
+  "outDir": "./lib"
+},
+"include": ["./src"],
+"exclude": ["./lib", "./node_modules"]
 ```
 
 for Backend using both Javascript and Typescript:
 
 ```json
 "extends": "@day1co/tsconfig/backend-mixed.json"
+"compilerOptions": {
+  "outDir": "./lib"
+},
+"include": ["./src"],
+"exclude": ["./lib", "./node_modules"]
 ```
 
 ---
+
 may the **SOURCE** be with you...

--- a/tsconfig/backend.json
+++ b/tsconfig/backend.json
@@ -12,14 +12,11 @@
     "types": ["node", "jest"],
     "declaration": true,
     "newLine": "lf",
-    "outDir": "./lib",
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "target": "es2021"
-  },
-  "include": ["./src"],
-  "exclude": ["./lib", "./node_modules"]
+  }
 }

--- a/tsconfig/common.json
+++ b/tsconfig/common.json
@@ -12,14 +12,11 @@
     "types": ["jest"],
     "declaration": true,
     "newLine": "lf",
-    "outDir": "./lib",
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "target": "es2021"
-  },
-  "include": ["./src"],
-  "exclude": ["./lib", "./node_modules"]
+  }
 }

--- a/tsconfig/package-lock.json
+++ b/tsconfig/package-lock.json
@@ -1,22 +1,28 @@
 {
   "name": "@day1co/tsconfig",
-  "version": "1.1.2",
-  "lockfileVersion": 3,
+  "version": "1.1.3",
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@day1co/tsconfig",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
-      "devDependencies": {
+      "dependencies": {
         "@tsconfig/node-lts": "^18.12.1"
       }
     },
     "node_modules/@tsconfig/node-lts": {
       "version": "18.12.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node-lts/-/node-lts-18.12.1.tgz",
-      "integrity": "sha512-UkIaMWDwJ+qJX/os8lzYh7m47qQJY7sIp1WZiEStASrpzczp27+jA0fJES+IjnS2OlDDLeBghNrVkKw8iYIRdA==",
-      "dev": true
+      "integrity": "sha512-UkIaMWDwJ+qJX/os8lzYh7m47qQJY7sIp1WZiEStASrpzczp27+jA0fJES+IjnS2OlDDLeBghNrVkKw8iYIRdA=="
+    }
+  },
+  "dependencies": {
+    "@tsconfig/node-lts": {
+      "version": "18.12.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node-lts/-/node-lts-18.12.1.tgz",
+      "integrity": "sha512-UkIaMWDwJ+qJX/os8lzYh7m47qQJY7sIp1WZiEStASrpzczp27+jA0fJES+IjnS2OlDDLeBghNrVkKw8iYIRdA=="
     }
   }
 }

--- a/tsconfig/package.json
+++ b/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@day1co/tsconfig",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "Day1Company",
   "license": "MIT",
   "repository": {
@@ -10,7 +10,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
-  "devDependencies": {
+  "dependencies": {
     "@tsconfig/node-lts": "^18.12.1"
   }
 }


### PR DESCRIPTION
문제
1. tsconfig.json 내의 상대 경로는 tsconfig.json 파일의 위치를 기준으로 하기 때문에 @day1co/tsconfig를 사용하는 쪽에서는 해당 경로가 node_modules/@day1co/tsconfig 가 된다.
2. @tsconfig/node-lts가 devDependencies에 들어가 있으면 @day1co/tsconfig를 사용하는 쪽에서는 제대로 설치되지 않는다.

해결
1. outDir, include, exclude 등의 경로가 들어가는 설정은 지우고 각 프로젝트에서 설정하도록 한다.
2. @tsconfig/node-lts를 dependencies에 포함시킨다
