### PR TITLE
node-lts dependency 제거

### DIFF
--- a/tsconfig/package-lock.json
+++ b/tsconfig/package-lock.json
@@ -1,28 +1,13 @@
 {
   "name": "@day1co/tsconfig",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@day1co/tsconfig",
-      "version": "1.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@tsconfig/node-lts": "^18.12.1"
-      }
-    },
-    "node_modules/@tsconfig/node-lts": {
-      "version": "18.12.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node-lts/-/node-lts-18.12.1.tgz",
-      "integrity": "sha512-UkIaMWDwJ+qJX/os8lzYh7m47qQJY7sIp1WZiEStASrpzczp27+jA0fJES+IjnS2OlDDLeBghNrVkKw8iYIRdA=="
-    }
-  },
-  "dependencies": {
-    "@tsconfig/node-lts": {
-      "version": "18.12.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node-lts/-/node-lts-18.12.1.tgz",
-      "integrity": "sha512-UkIaMWDwJ+qJX/os8lzYh7m47qQJY7sIp1WZiEStASrpzczp27+jA0fJES+IjnS2OlDDLeBghNrVkKw8iYIRdA=="
+      "version": "1.2.2",
+      "license": "MIT"
     }
   }
 }

--- a/tsconfig/package.json
+++ b/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@day1co/tsconfig",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Day1Company",
   "license": "MIT",
   "repository": {

--- a/tsconfig/package.json
+++ b/tsconfig/package.json
@@ -9,8 +9,5 @@
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
-  },
-  "dependencies": {
-    "@tsconfig/node-lts": "^18.12.1"
   }
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
node-lts 모듈이 runtime에 필요한 것이 아닌데 dependency로 걸려있다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
여기서 @tsconfig/node-lts 를 devDependency에 걸어놓아도
@day1co/tsconfig 를 쓰는 쪽에서 어짜피 @tsconfig/node-lts에 대한 의존성을 똑같이 devDependency에 걸어야 한다.
(README에서도 @tsconfig/node-lts 추가하도록 하고 있다)
그렇다면 굳이 여기에 의존성을 남겨둘 이유가 없다.
다만 이걸 변경하면 @day1co/tsconfig 를 사용하는 모든 모듈의 의존성을 수정해야한다.

## 디펜던시 변경이 있나요?
@tsconfig/node-lts 제거
