### PR TITLE
misc: change GitHub token in secrets to GH_TOKEN

### DIFF
--- a/stylelint-config/.github/workflows/npm-publish.yml
+++ b/stylelint-config/.github/workflows/npm-publish.yml
@@ -11,8 +11,8 @@ on:
       - .github/**/*
 
 env:
-  PUSH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  PACKAGE_TOKEN: ${{ secrets.NPM_TOKEN }}
+  PUSH_TOKEN: ${{ secrets.GH_TOKEN }}
+  PACKAGE_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   ci-label-test:
@@ -29,7 +29,7 @@ jobs:
       - uses: 8BitJonny/gh-get-current-pr@1.1.0
         id: PR
         with:
-          github-token: ${{ secrets.NPM_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
 
   build:
     needs: ci-label-test

--- a/stylelint-config/.github/workflows/release-drafter.yml
+++ b/stylelint-config/.github/workflows/release-drafter.yml
@@ -14,5 +14,4 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
https://fastcampus.atlassian.net/browse/COMMON-157

## 무엇을 어떻게 변경했나요?
깃헙에서 사용하는 npm 관련 토큰을 GH_TOKEN 으로 통일

