### PR TITLE
misc: @tsconfig/node-lts  버전을 18.12.1 로 고정

### DIFF
--- a/tsconfig/package.json
+++ b/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@day1co/tsconfig",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Day1Company",
   "license": "MIT",
   "repository": {
@@ -11,6 +11,6 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "@tsconfig/node-lts": "^18.12.1"
+    "@tsconfig/node-lts": "18.12.1"
   }
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 새로운 기능

## 무엇을 어떻게 변경했나요?
misc: @tsconfig/node-lts  버전을 18.12.1 로 고정합니다

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
@day1co/tsconfig 설치시 @tsconfig/node-lts가 최신버전으로 설치되는데
LTS가 20으로 변경되면서 tyepscript 4버전대에서 빌드가 안되는 문제가 있었습니다.

## 어떻게 테스트 하셨나요?
휴먼 아이