### PR TITLE
fix: unset pathGroupsExcludedImportTypes defaults

### DIFF
--- a/eslint-config/common-ts.js
+++ b/eslint-config/common-ts.js
@@ -25,10 +25,11 @@ module.exports = {
         pathGroups: [
           {
             pattern: '@day1co/**',
-            group: 'internal',
-            position: 'before',
+            group: 'external',
+            position: 'after',
           },
         ],
+        pathGroupsExcludedImportTypes: [], 
       },
     ]
   },


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

`pathGroups` 설정에 이슈가 있어 수정합니다.
`@day1co/**` 면 `external`그룹에 속하는데,  이 그룹이 `pathGroupsExcludedImportTypes` 에 지정되어 있지 않아야 합니다. (기본값은 `["builtin", "external", "object"]`)

참고: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#pathgroupsexcludedimporttypes-array 

## 무엇을 어떻게 변경했나요?

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
